### PR TITLE
Feature/django 3 compatibility

### DIFF
--- a/action_notifications/messages.py
+++ b/action_notifications/messages.py
@@ -7,7 +7,7 @@ except ImportError:
     from django.db.models.loading import get_model
 
 from django.conf import settings
-from django.utils import six
+import six
 
 handlers = []
 

--- a/action_notifications/templates/action_notifications/base_html_email.txt
+++ b/action_notifications/templates/action_notifications/base_html_email.txt
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+{% load static %}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def get_package_data(package):
 
 setup(
     name='django-action-notifications',
-    version='0.0.20',
+    version='0.0.21',
     packages=get_packages('action_notifications'),
     include_package_data=True,
     package_data=get_package_data('action_notifications'),


### PR DESCRIPTION
load static instead of load staticfiles in email template -  staticfiles deprecated in django 2.1, removed in 3
use six instead of django.utils.six (removed from django 3.0 onwards)

increment version

https://docs.djangoproject.com/en/2.2/releases/2.1/#features-deprecated-in-2-1
https://six.readthedocs.io/
